### PR TITLE
Add toast notifications with safe button binding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/game.js
+++ b/game.js
@@ -1,0 +1,30 @@
+function showToast(message) {
+  const toast = document.createElement('div');
+  toast.className = 'toast';
+  toast.textContent = message;
+  document.body.appendChild(toast);
+  requestAnimationFrame(() => toast.classList.add('show'));
+  setTimeout(() => {
+    toast.classList.remove('show');
+    setTimeout(() => toast.remove(), 300);
+  }, 2000);
+}
+
+function bindButton(id, message) {
+  const btn = document.getElementById(id);
+  if (!btn) {
+    console.warn(`Button with id ${id} not found`);
+    return;
+  }
+  btn.addEventListener('click', () => {
+    showToast(message);
+  });
+}
+
+bindButton('giveBtn', 'You gave a gift!');
+bindButton('sarcasmBtn', 'Sarcasm deployed!');
+bindButton('coffeeBtn', 'Coffee purchased!');
+
+if (typeof module !== 'undefined') {
+  module.exports = { showToast, bindButton };
+}

--- a/game.test.js
+++ b/game.test.js
@@ -1,0 +1,62 @@
+/**
+ * @jest-environment jsdom
+ */
+
+global.requestAnimationFrame = (cb) => cb();
+
+describe('showToast', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  test('adds and removes toast element with correct text', () => {
+    jest.isolateModules(() => {
+      const { showToast } = require('./game');
+      showToast('Test');
+    });
+
+    const toast = document.querySelector('.toast');
+    expect(toast).not.toBeNull();
+    expect(toast.textContent).toBe('Test');
+    expect(toast.classList.contains('show')).toBe(true);
+
+    jest.advanceTimersByTime(2300);
+    expect(document.querySelector('.toast')).toBeNull();
+  });
+});
+
+describe('button clicks', () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <button id="giveBtn"></button>
+      <button id="sarcasmBtn"></button>
+      <button id="coffeeBtn"></button>
+    `;
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  const cases = [
+    ['giveBtn', 'You gave a gift!'],
+    ['sarcasmBtn', 'Sarcasm deployed!'],
+    ['coffeeBtn', 'Coffee purchased!'],
+  ];
+
+  test.each(cases)('clicking %s shows toast with message', (id, message) => {
+    jest.isolateModules(() => require('./game'));
+    document.getElementById(id).click();
+    const toast = document.querySelector('.toast');
+    expect(toast).not.toBeNull();
+    expect(toast.textContent).toBe(message);
+  });
+});

--- a/index.html
+++ b/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Bookish Tribble Game</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header>
+    <h1>Bookish Tribble</h1>
+  </header>
+  <main>
+    <button id="giveBtn">Give</button>
+    <button id="sarcasmBtn">Sarcasm</button>
+    <button id="coffeeBtn">Coffee</button>
+  </main>
+  <script src="game.js"></script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "bookish-tribble",
+  "version": "1.0.0",
+  "description": "",
+  "main": "game.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^29.7.0"
+  }
+}

--- a/style.css
+++ b/style.css
@@ -1,0 +1,35 @@
+body {
+  font-family: sans-serif;
+  margin: 0;
+  padding: 0;
+  text-align: center;
+}
+header {
+  background: #222;
+  color: #fff;
+  padding: 10px 20px;
+}
+main {
+  margin-top: 40px;
+}
+button {
+  margin: 10px;
+  padding: 10px 20px;
+  font-size: 16px;
+}
+.toast {
+  position: fixed;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(0, 0, 0, 0.8);
+  color: #fff;
+  padding: 10px 20px;
+  border-radius: 4px;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  pointer-events: none;
+}
+.toast.show {
+  opacity: 1;
+}


### PR DESCRIPTION
## Summary
- remove binary audio assets and related code
- keep toast notifications for achievements or purchases
- guard button bindings with console warnings if elements are missing
- export helper functions and add Jest tests for toast notifications and button events

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896ed4d4a3c83218ea88b375d3aefc0